### PR TITLE
Add optional --url argument

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 160

--- a/stick/commands.py
+++ b/stick/commands.py
@@ -31,6 +31,7 @@ def cli():
 
 @cli.command(context_settings={'max_content_width': 120, 'ignore_unknown_options': True})
 @click.option('--bucket', help='S3 Bucket hosting the repository.', required=True)
+@click.option('--url', help='Override the S3-based repository URL.', default=None)
 @click.option('--prefix', help='Prefix within the S3 Bucket that repository objects are stored.', default='simple', show_default=True)
 @click.option('--profile', help='Use a specific profile from your credential file to access S3.', default=None)
 @click.option('--skip-existing/--no-skip-existing', help='Skip uploading file if it already exists.', default=True, show_default=True)
@@ -71,6 +72,7 @@ def upload(dist, **kwargs):
 
 @cli.command(context_settings={'max_content_width': 120})
 @click.option('--bucket', help='S3 Bucket hosting the repository.', required=True)
+@click.option('--url', help='Override the S3-based repository URL.', default=None)
 @click.option('--prefix', help='Prefix within the S3 Bucket that repository objects are stored.', default='simple', show_default=True)
 @click.option('--profile', help='Use a specific profile from your credential file to access S3.', default=None)
 @click.option('--project', help='Reindex a specific project. May be specified multiple times.  [default: all projects]', default=None, multiple=True)
@@ -87,6 +89,7 @@ def reindex(project, **kwargs):
 
 @cli.command(context_settings={'max_content_width': 120})
 @click.option('--bucket', help='S3 Bucket hosting the repository.', required=True)
+@click.option('--url', help='Override the S3-based repository URL.', default=None)
 @click.option('--prefix', help='Prefix within the S3 Bucket that repository objects are stored.', default='simple', show_default=True)
 @click.option('--profile', help='Use a specific profile from your credential file to access S3.', default=None)
 @click.option('--project', help='Check a specific project. May be specified multiple times.  [default: all projects]', default=None, multiple=True)

--- a/stick/repository.py
+++ b/stick/repository.py
@@ -1,3 +1,4 @@
+import codecs
 import io
 import json
 import logging
@@ -176,7 +177,9 @@ class Repository(object):
         json_key = '{0}{1}/manifest.json'.format(self.prefix, safe_name)
         logger.info('Uploading {0}'.format(json_key))
         with io.BytesIO() as data:
-            json.dump(project.get_manifest(), data)
+            writer = codecs.getwriter("utf-8")
+            str_data = writer(data)
+            json.dump(project.get_manifest(), str_data)
             data.seek(0, 0)
             return self.client.put_object(Body=data, Bucket=self.bucket, Key=json_key, ContentType='application/json; charset=utf-8')
 
@@ -186,7 +189,9 @@ class Repository(object):
         json_key = '{0}{1}{2}/json'.format(self.prefix, safe_name, version_prefix)
         logger.info('Uploading {0}'.format(json_key))
         with io.BytesIO() as data:
-            json.dump(project.get_metadata(version), data)
+            writer = codecs.getwriter("utf-8")
+            str_data = writer(data)
+            json.dump(project.get_metadata(version), str_data)
             data.seek(0, 0)
             return self.client.put_object(Body=data, Bucket=self.bucket, Key=json_key, ContentType='application/json; charset=utf-8')
 

--- a/stick/repository.py
+++ b/stick/repository.py
@@ -19,8 +19,9 @@ logger = logging.getLogger(__name__)
 
 
 class Repository(object):
-    def __init__(self, bucket, prefix, profile):
+    def __init__(self, bucket, url, prefix, profile):
         self.bucket = bucket
+        self.url = url
         self.prefix = prefix
         self.client = boto3.Session(profile_name=profile).client('s3', config=client_config)
         self._project_cache = {}
@@ -29,7 +30,10 @@ class Repository(object):
             self.prefix += '/'
 
     def get_url(self):
-        url = 'https://{0}.s3.amazonaws.com/{1}'.format(self.bucket, self.prefix)
+        if self.url is None:
+            url = 'https://{0}.s3.amazonaws.com/{1}'.format(self.bucket, self.prefix)
+        else:
+            url = '{0}/{1}'.format(self.url, self.prefix)
         return url
 
     def reindex(self, projects):

--- a/stick/repository.py
+++ b/stick/repository.py
@@ -18,8 +18,9 @@ logger = logging.getLogger(__name__)
 
 
 class Repository(object):
-    def __init__(self, bucket, prefix, profile):
+    def __init__(self, bucket, url, prefix, profile):
         self.bucket = bucket
+        self.url = url
         self.prefix = prefix
         self.client = boto3.Session(profile_name=profile).client('s3', config=client_config)
         self._project_cache = {}
@@ -28,7 +29,10 @@ class Repository(object):
             self.prefix += '/'
 
     def get_url(self):
-        url = 'https://{0}.s3.amazonaws.com/{1}'.format(self.bucket, self.prefix)
+        if self.url is None:
+            url = 'https://{0}.s3.amazonaws.com/{1}'.format(self.bucket, self.prefix)
+        else:
+            url = '{0}/{1}'.format(self.url, self.prefix)
         return url
 
     def reindex(self, projects):

--- a/stick/repository.py
+++ b/stick/repository.py
@@ -169,14 +169,14 @@ class Repository(object):
         with io.BytesIO() as data:
             self.client.download_fileobj(Fileobj=data, Bucket=self.bucket, Key=json_key)
             data.seek(0, 0)
-            return json.load(io.TextIOWrapper(data))
+            return json.load(io.TextIOWrapper(data, encoding='utf-8'))
 
     def _put_manifest(self, safe_name, project):
         """Dump and upload the project manifest JSON"""
         json_key = '{0}{1}/manifest.json'.format(self.prefix, safe_name)
         logger.info('Uploading {0}'.format(json_key))
         with io.BytesIO() as data:
-            json.dump(project.get_manifest(), data)
+            json.dump(project.get_manifest(), io.TextIOWrapper(data, encoding='utf-8'))
             data.seek(0, 0)
             return self.client.put_object(Body=data, Bucket=self.bucket, Key=json_key, ContentType='application/json; charset=utf-8')
 
@@ -186,7 +186,7 @@ class Repository(object):
         json_key = '{0}{1}{2}/json'.format(self.prefix, safe_name, version_prefix)
         logger.info('Uploading {0}'.format(json_key))
         with io.BytesIO() as data:
-            json.dump(project.get_metadata(version), data)
+            json.dump(project.get_metadata(version), io.TextIOWrapper(data, encoding='utf-8'))
             data.seek(0, 0)
             return self.client.put_object(Body=data, Bucket=self.bucket, Key=json_key, ContentType='application/json; charset=utf-8')
 

--- a/stick/repository.py
+++ b/stick/repository.py
@@ -176,9 +176,11 @@ class Repository(object):
         json_key = '{0}{1}/manifest.json'.format(self.prefix, safe_name)
         logger.info('Uploading {0}'.format(json_key))
         with io.BytesIO() as data:
-            json.dump(project.get_manifest(), io.TextIOWrapper(data, encoding='utf-8'))
-            data.seek(0, 0)
-            return self.client.put_object(Body=data, Bucket=self.bucket, Key=json_key, ContentType='application/json; charset=utf-8')
+            with io.TextIOWrapper(data, encoding='utf-8') as text:
+                json.dump(project.get_manifest(), text)
+                text.flush()
+                data.seek(0, 0)
+                return self.client.put_object(Body=data, Bucket=self.bucket, Key=json_key, ContentType='application/json; charset=utf-8')
 
     def _put_json(self, safe_name, project, version=None):
         """Regenerate and upload the project or release-level index JSON"""
@@ -186,9 +188,11 @@ class Repository(object):
         json_key = '{0}{1}{2}/json'.format(self.prefix, safe_name, version_prefix)
         logger.info('Uploading {0}'.format(json_key))
         with io.BytesIO() as data:
-            json.dump(project.get_metadata(version), io.TextIOWrapper(data, encoding='utf-8'))
-            data.seek(0, 0)
-            return self.client.put_object(Body=data, Bucket=self.bucket, Key=json_key, ContentType='application/json; charset=utf-8')
+            with io.TextIOWrapper(data, encoding='utf-8') as text:
+                json.dump(project.get_metadata(version), text)
+                text.flush()
+                data.seek(0, 0)
+                return self.client.put_object(Body=data, Bucket=self.bucket, Key=json_key, ContentType='application/json; charset=utf-8')
 
     def _put_index(self, safe_name, project):
         """Regenerate and upload the project-level index HTML"""

--- a/stick/settings.py
+++ b/stick/settings.py
@@ -2,8 +2,9 @@ from .repository import Repository
 
 
 class Settings(object):
-    def __init__(self, bucket, prefix, profile=None, skip_existing=True, sign=False, sign_with='gpg', identity=None):
+    def __init__(self, bucket, url, prefix, profile=None, skip_existing=True, sign=False, sign_with='gpg', identity=None):
         self.bucket = bucket
+        self.url = url
         self.prefix = prefix
         self.profile = profile
         self.skip_existing = skip_existing
@@ -12,5 +13,5 @@ class Settings(object):
         self.identity = identity
 
     def create_repository(self):
-        repo = Repository(self.bucket, self.prefix, self.profile)
+        repo = Repository(self.bucket, self.url, self.prefix, self.profile)
         return repo


### PR DESCRIPTION
Fixes #2.

This allows the user to use an explicitly-provided URL instead of one generated from the bucket name; it's useful particularly for CloudFront, where we want to expose a FQDN that is totally different from the underlying bucket name.

NB. I am not a git wizard, and there's still some old IO. crud that leaked through despite my best efforts to clean up this PR. Just ignore the obviously non-url-related crud in the diff.

Thanks,
Scott